### PR TITLE
chore: modify event publisher and test class

### DIFF
--- a/src/main/java/fr/redfroggy/keycloak/SnsEventPublisher.java
+++ b/src/main/java/fr/redfroggy/keycloak/SnsEventPublisher.java
@@ -13,36 +13,43 @@ class SnsEventPublisher {
     private static final Logger log = Logger.getLogger(SnsEventPublisher.class);
     private final SnsEventListenerConfiguration snsEventListenerConfiguration;
 
-    public SnsEventPublisher(AmazonSNSAsync snsClient, SnsEventListenerConfiguration snsEventListenerConfiguration, ObjectMapper mapper) {
+    public SnsEventPublisher(AmazonSNSAsync snsClient, SnsEventListenerConfiguration snsEventListenerConfiguration,
+            ObjectMapper mapper) {
         this.snsClient = snsClient;
         this.snsEventListenerConfiguration = snsEventListenerConfiguration;
         this.mapper = mapper;
     }
 
     public void sendEvent(SnsEvent snsEvent) {
-        if (snsEventListenerConfiguration.getEventTopicArn() == null) {
-            log.warn("No topicArn specified. Can not send event to AWS SNS! Set environment variable KC_SNS_EVENT_TOPIC_ARN");
-            return;
+        try {
+            if (snsEventListenerConfiguration.getEventTopicArn() == null) {
+                throw new Exception();
+            }
+            publishEvent(snsEvent, snsEventListenerConfiguration.getEventTopicArn());
+
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-        publishEvent(snsEvent,snsEventListenerConfiguration.getEventTopicArn());
     }
 
     public void sendAdminEvent(SnsAdminEvent snsAdminEvent) {
-        if (snsEventListenerConfiguration.getAdminEventTopicArn() == null) {
-            log.warn("No topicArn specified. Can not send event to AWS SNS! Set environment variable KC_SNS_ADMIN_EVENT_TOPIC_ARN");
-            return;
-        }
-        publishEvent(snsAdminEvent, snsEventListenerConfiguration.getAdminEventTopicArn());
-    }   
+        try {
+            if (snsEventListenerConfiguration.getAdminEventTopicArn() == null) {
+                throw new Exception();
+            }
+            publishEvent(snsAdminEvent, snsEventListenerConfiguration.getAdminEventTopicArn());
 
-    private void publishEvent(Object event, String topicArn){        
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void publishEvent(Object event, String topicArn) {
         try {
             snsClient.publish(topicArn, mapper.writeValueAsString(event));
         } catch (JsonProcessingException e) {
             log.error("The payload wasn't created.", e);
             return;
         }
-        
     }
-
 }

--- a/src/main/java/fr/redfroggy/keycloak/SnsEventPublisher.java
+++ b/src/main/java/fr/redfroggy/keycloak/SnsEventPublisher.java
@@ -21,27 +21,21 @@ class SnsEventPublisher {
     }
 
     public void sendEvent(SnsEvent snsEvent) {
-        try {
-            if (snsEventListenerConfiguration.getEventTopicArn() == null) {
-                throw new Exception();
-            }
-            publishEvent(snsEvent, snsEventListenerConfiguration.getEventTopicArn());
-
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (snsEventListenerConfiguration.getEventTopicArn() == null) {
+            log.warn(
+                    "No topicArn specified. Can not send event to AWS SNS! Set environment variable KC_SNS_EVENT_TOPIC_ARN");
+            return;
         }
-    }
+        publishEvent(snsEvent, snsEventListenerConfiguration.getEventTopicArn());
+        }
 
     public void sendAdminEvent(SnsAdminEvent snsAdminEvent) {
-        try {
-            if (snsEventListenerConfiguration.getAdminEventTopicArn() == null) {
-                throw new Exception();
-            }
-            publishEvent(snsAdminEvent, snsEventListenerConfiguration.getAdminEventTopicArn());
-
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (snsEventListenerConfiguration.getAdminEventTopicArn() == null) {
+            log.warn(
+                    "No topicArn specified. Can not send event to AWS SNS! Set environment variable KC_SNS_ADMIN_EVENT_TOPIC_ARN");
+            return;
         }
+        publishEvent(snsAdminEvent, snsEventListenerConfiguration.getAdminEventTopicArn());
     }
 
     private void publishEvent(Object event, String topicArn) {
@@ -49,7 +43,8 @@ class SnsEventPublisher {
             snsClient.publish(topicArn, mapper.writeValueAsString(event));
         } catch (JsonProcessingException e) {
             log.error("The payload wasn't created.", e);
-            return;
+        } catch (Exception e) {
+            log.error("Exception occured during the event publication",e);
         }
     }
 }

--- a/src/main/java/fr/redfroggy/keycloak/SnsEventPublisher.java
+++ b/src/main/java/fr/redfroggy/keycloak/SnsEventPublisher.java
@@ -27,7 +27,7 @@ class SnsEventPublisher {
             return;
         }
         publishEvent(snsEvent, snsEventListenerConfiguration.getEventTopicArn());
-        }
+    }
 
     public void sendAdminEvent(SnsAdminEvent snsAdminEvent) {
         if (snsEventListenerConfiguration.getAdminEventTopicArn() == null) {
@@ -44,7 +44,7 @@ class SnsEventPublisher {
         } catch (JsonProcessingException e) {
             log.error("The payload wasn't created.", e);
         } catch (Exception e) {
-            log.error("Exception occured during the event publication",e);
+            log.error("Exception occured during the event publication", e);
         }
     }
 }

--- a/src/test/java/fr/redfroggy/keycloak/SnsEventPublisherTest.java
+++ b/src/test/java/fr/redfroggy/keycloak/SnsEventPublisherTest.java
@@ -48,7 +48,7 @@ class SnsEventPublisherTest {
     }
 
     @Test
-    void shouldSendAdminEventWhenEventTopicArnExists() throws JsonProcessingException{
+    void shouldSendAdminEventWhenEventTopicArnExists() throws JsonProcessingException {
         when(snsEventListenerConfigurationMock.getAdminEventTopicArn()).thenReturn("adminEventTopicArn");
         when(mapperMock.writeValueAsString(snsAdminEventMock)).thenReturn("adminEventJSONString");
         snsEventPublisher.sendAdminEvent(snsAdminEventMock);
@@ -66,7 +66,7 @@ class SnsEventPublisherTest {
         when(snsEventListenerConfigurationMock.getEventTopicArn()).thenReturn("eventTopicArn");
         when(mapperMock.writeValueAsString(snsEventMock)).thenThrow(JsonProcessingException.class);
         snsEventPublisher.sendEvent(snsEventMock);
-        verify(snsClientMock, never()).publish(any(),any());        
+        verify(snsClientMock, never()).publish(any(),any());
     }
 
     @Test

--- a/src/test/java/fr/redfroggy/keycloak/SnsEventPublisherTest.java
+++ b/src/test/java/fr/redfroggy/keycloak/SnsEventPublisherTest.java
@@ -29,13 +29,12 @@ class SnsEventPublisherTest {
 
     @Mock
     private SnsEventListenerConfiguration snsEventListenerConfigurationMock;
-    
+
     @InjectMocks
     private SnsEventPublisher snsEventPublisher;
 
-    
     @Test
-    void shouldSendEventWhenEventTopicArnExists()  throws JsonProcessingException {
+    void shouldSendEventWhenEventTopicArnExists() throws JsonProcessingException {
         when(snsEventListenerConfigurationMock.getEventTopicArn()).thenReturn("eventTopicArn");
         when(mapperMock.writeValueAsString(snsEventMock)).thenReturn("eventJSONString");
         snsEventPublisher.sendEvent(snsEventMock);
@@ -43,9 +42,9 @@ class SnsEventPublisherTest {
     }
 
     @Test
-    void shouldNotSendEventWhenEventTopicArnDoenstExistsAndThrowAnException() throws Exception{
+    void shouldNotSendEventWhenEventTopicArnDoenstExistsAndGetAWarning() {
         snsEventPublisher.sendEvent(snsEventMock);
-        verify(snsClientMock, never()).publish(any(),any());
+        verify(snsClientMock, never()).publish(any(), any());
     }
 
     @Test
@@ -57,17 +56,23 @@ class SnsEventPublisherTest {
     }
 
     @Test
-    void shouldNotSendAdminEventWhenEventTopicArnDoenstExistsAndThrowAnException(){
+    void shouldNotSendAdminEventWhenEventTopicArnDoenstExistsAndGetAWarning() {
         snsEventPublisher.sendAdminEvent(snsAdminEventMock);
-        verify(snsClientMock, never()).publish(any(),any());
+        verify(snsClientMock, never()).publish(any(), any());
     }
 
     @Test
-    void shouldNotSendEventAndLogAnErrorWhenAnyValueIsWrite() throws JsonProcessingException  {
+    void shouldNotSendEventAndLogAnErrorWhenAnyValueIsWrite() throws JsonProcessingException {
         when(snsEventListenerConfigurationMock.getEventTopicArn()).thenReturn("eventTopicArn");
         when(mapperMock.writeValueAsString(snsEventMock)).thenThrow(JsonProcessingException.class);
         snsEventPublisher.sendEvent(snsEventMock);
-        verify(snsClientMock, never()).publish(any(),any());
+        verify(snsClientMock, never()).publish(any(),any());        
     }
 
+    @Test
+    void shouldNotPropagateRuntimeExceptionIfPublishFailed() {
+        when(snsEventListenerConfigurationMock.getEventTopicArn()).thenReturn("eventTopicArn");
+        when(snsClientMock.publish(any(),any())).thenThrow(new RuntimeException("test"));
+        snsEventPublisher.sendEvent(snsEventMock);
+    }
 }

--- a/src/test/java/fr/redfroggy/keycloak/SnsEventPublisherTest.java
+++ b/src/test/java/fr/redfroggy/keycloak/SnsEventPublisherTest.java
@@ -35,7 +35,7 @@ class SnsEventPublisherTest {
 
     
     @Test
-    void shouldSendEventWhenEventTopicArnExists() throws JsonProcessingException{
+    void shouldSendEventWhenEventTopicArnExists()  throws JsonProcessingException {
         when(snsEventListenerConfigurationMock.getEventTopicArn()).thenReturn("eventTopicArn");
         when(mapperMock.writeValueAsString(snsEventMock)).thenReturn("eventJSONString");
         snsEventPublisher.sendEvent(snsEventMock);
@@ -43,7 +43,7 @@ class SnsEventPublisherTest {
     }
 
     @Test
-    void shouldNotSendEventWhenEventTopicArnDoenstExistsAndGetAWarning(){
+    void shouldNotSendEventWhenEventTopicArnDoenstExistsAndThrowAnException() throws Exception{
         snsEventPublisher.sendEvent(snsEventMock);
         verify(snsClientMock, never()).publish(any(),any());
     }
@@ -57,13 +57,13 @@ class SnsEventPublisherTest {
     }
 
     @Test
-    void shouldNotSendAdminEventWhenEventTopicArnDoenstExists(){
+    void shouldNotSendAdminEventWhenEventTopicArnDoenstExistsAndThrowAnException(){
         snsEventPublisher.sendAdminEvent(snsAdminEventMock);
         verify(snsClientMock, never()).publish(any(),any());
     }
 
     @Test
-    void shouldNotSendEventAndLogAnErrorWhenAnyValueIsWrite() throws JsonProcessingException {
+    void shouldNotSendEventAndLogAnErrorWhenAnyValueIsWrite() throws JsonProcessingException  {
         when(snsEventListenerConfigurationMock.getEventTopicArn()).thenReturn("eventTopicArn");
         when(mapperMock.writeValueAsString(snsEventMock)).thenThrow(JsonProcessingException.class);
         snsEventPublisher.sendEvent(snsEventMock);


### PR DESCRIPTION
Added try-catch in sendEvent methods to fix the possible "ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-2) Uncaught server error: com.amazonaws.services.sns.model.AmazonSNSException: The security token included in the request is invalid. (Service: AmazonSNS; Status Code: 403; Error Code: InvalidClientTokenId; Request ID: 3ced6f11-b742-5f15-957e-335d2f5a9e59; Proxy: null)"